### PR TITLE
Fixing bug where no message output is displayed in code_metrics and renaming metric prototypes.

### DIFF
--- a/tools/code_metrics/SCRIPT.txt
+++ b/tools/code_metrics/SCRIPT.txt
@@ -54,11 +54,11 @@ ________________________________________________________________________
 % enumerate, by backtracking, the scores for number of clauses, depth of
 % inheritance tree, and coupling, for the built-in logtalk object:
 
-| ?- noc::item_score(logtalk, Score).
+| ?- noc_metric::item_score(logtalk, Score).
 ...
 
-| ?- dit::item_score(logtalk, Score).
+| ?- dit_metric::item_score(logtalk, Score).
 ...
 
-| ?- coupling::item_score(logtalk, Score).
+| ?- coupling_metric::item_score(logtalk, Score).
 ...

--- a/tools/code_metrics/code_metrics.lgt
+++ b/tools/code_metrics/code_metrics.lgt
@@ -111,7 +111,7 @@
 		).
 
 	process_item_(Item, Metric, Score) :-
-		imports_category(Metric, analysis),
+		imports_category(Metric, code_metrics_utilities),
 		Metric::item_score(Item, Score).
 
 	%%%%%%%%%%%%%%%%

--- a/tools/code_metrics/code_metrics_messages.lgt
+++ b/tools/code_metrics/code_metrics_messages.lgt
@@ -70,24 +70,24 @@
 		item_score(Item, Metric, Score).
 
 	item_score(_Item, Metric, Score) -->
-		{	(	Metric == dit
-			;	Metric == coupling
+		{	(	Metric == dit_metric
+			;	Metric == coupling_metric
 			),
 			!,
 			metric_label(Metric, Label)
 		},
 		['~w score: ~w'-[Label, Score], nl].
 
-	item_score(_Item, noc, predicate_noc(Predicate, Score)) -->
+	item_score(_Item, noc_metric, predicate_noc(Predicate, Score)) -->
 		{ metric_label(noc, Label) },
 		['~w [~w]: ~w'-[Label, Predicate, Score], nl].
 
 	% auxiliary predicates
 
 	% for expanding the metric objects into more meaninful names for the user
-	object_label(dit, 'Depth of Inheritance').
-	object_label(coupling, 'Coupling').
-	object_label(noc, 'Number of Clauses').
+	object_label(dit_metric, 'Depth of Inheritance').
+	object_label(coupling_metric, 'Coupling').
+	object_label(noc_metric, 'Number of Clauses').
 
 	metric_label(MetricObject, Label) :-
 		(	object_label(MetricObject, MetricLabel) ->

--- a/tools/code_metrics/code_metrics_messages.lgt
+++ b/tools/code_metrics/code_metrics_messages.lgt
@@ -79,7 +79,7 @@
 		['~w score: ~w'-[Label, Score], nl].
 
 	item_score(_Item, noc_metric, predicate_noc(Predicate, Score)) -->
-		{ metric_label(noc, Label) },
+		{ metric_label(noc_metric, Label) },
 		['~w [~w]: ~w'-[Label, Predicate, Score], nl].
 
 	% auxiliary predicates

--- a/tools/code_metrics/metrics/coupling_metric.lgt
+++ b/tools/code_metrics/metrics/coupling_metric.lgt
@@ -19,7 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-:- object(coupling,
+:- object(coupling_metric,
 	implements(code_metrics_protocol),
 	imports(code_metrics_utilities)).
 

--- a/tools/code_metrics/metrics/dit_metric.lgt
+++ b/tools/code_metrics/metrics/dit_metric.lgt
@@ -19,7 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-:- object(dit,
+:- object(dit_metric,
 	implements(code_metrics_protocol),
 	imports(code_metrics_utilities)).
 

--- a/tools/code_metrics/metrics/loader.lgt
+++ b/tools/code_metrics/metrics/loader.lgt
@@ -21,8 +21,8 @@
 
 :- initialization(
 	logtalk_load([
-		dit,
-		coupling,
-		noc
+		dit_metric,
+		coupling_metric,
+		noc_metric
 	])
 ).

--- a/tools/code_metrics/metrics/noc_metric.lgt
+++ b/tools/code_metrics/metrics/noc_metric.lgt
@@ -19,7 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-:- object(noc,
+:- object(noc_metric,
 	implements(code_metrics_protocol),
 	imports(code_metrics_utilities)).
 

--- a/tools/code_metrics/tests.lgt
+++ b/tools/code_metrics/tests.lgt
@@ -154,7 +154,7 @@
 	% noc tests
 
 	test(noc_cat_a) :-
-		\+ noc::item_score(cat_a, _).
+		\+ noc_metric::item_score(cat_a, _).
 
 	test(noc_cat_b) :-
 		nocs_are(cat_b, Nocs),
@@ -165,7 +165,7 @@
 		Nocs == [foo/0-1].
 
 	test(noc_cat_d) :-
-		\+ noc::item_score(cat_d, _).
+		\+ noc_metric::item_score(cat_d, _).
 
 	test(wrong_clause(noc_obj_e)) :-
 		nocs_are(obj_e, Nocs),
@@ -192,25 +192,25 @@
 		Nocs == [foo/0-1].
 
 	test(noc_prot_a) :-
-		\+ noc::item_score(prot_a, _).
+		\+ noc_metric::item_score(prot_a, _).
 
 	test(noc_prot_b) :-
-		\+ noc::item_score(prot_b, _).
+		\+ noc_metric::item_score(prot_b, _).
 
 	test(noc_car) :-
-		\+ noc::item_score(car, _).
+		\+ noc_metric::item_score(car, _).
 
 	test(noc_vehicle) :-
-		\+ noc::item_score(vehicle, _).
+		\+ noc_metric::item_score(vehicle, _).
 
 	test(noc_meta_vehicle) :-
-		\+ noc::item_score(meta_vehicle, _).
+		\+ noc_metric::item_score(meta_vehicle, _).
 
 	test(noc_herring) :-
-		\+ noc::item_score(herring, _).
+		\+ noc_metric::item_score(herring, _).
 
 	test(noc_bird) :-
-		\+ noc::item_score(bird, _).
+		\+ noc_metric::item_score(bird, _).
 
 	% main interface tests
 
@@ -241,17 +241,17 @@
 	% convenience
 
 	coupling_is(Item, N) :-
-		findall(C, coupling::item_score(Item, C), Couplings),
+		findall(C, coupling_metric::item_score(Item, C), Couplings),
 		Couplings == [N].
 
 	depth_is(Item, N) :-
-		findall(D, dit::item_score(Item, D), Depths),
+		findall(D, dit_metric::item_score(Item, D), Depths),
 		Depths == [N].
 
 	nocs_are(Item, Nocs) :-
 		findall(
 			Predicate-Noc,
-			noc::item_score(Item, predicate_noc(Predicate, Noc)),
+			noc_metric::item_score(Item, predicate_noc(Predicate, Noc)),
 			Nocs
 		).
 


### PR DESCRIPTION
I forgot to change an entity name in `code_metrics.lgt`.