### PR TITLE
Code metrics ancestor patch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ the Logtalk directory, and then type:
 	% sudo ./install.sh
 
 This installation script makes all files read-only for non-admin users in 
-order to avoid user tempering. This is a convenient setup for computer labs, 
+order to avoid user tampering. This is a convenient setup for computer labs, 
 given that making directories world-writable is a security risk. The install
 script accepts an installation prefix as argument. For example:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,6 @@
     <li><a href="entity_index.html">Entity index</a></li>
     <li><a href="predicate_index.html">Predicate index</a></li>
 </ul>
-<p>Generated on Mon Feb 27 11:53:08 GMT 2017</p>
+<p>Generated on Mon Feb 27 10:10:43 PST 2017</p>
 </body>
 </html>

--- a/tools/code_metrics/code_metrics_utilities.lgt
+++ b/tools/code_metrics/code_metrics_utilities.lgt
@@ -22,9 +22,9 @@
 :- category(code_metrics_utilities).
 
 	:- info([
-		version is 0.1,
+		version is 0.2,
 		author is 'Ebrahim Azarisooreh',
-		date is 2016/1/10,
+		date is 2017/02/27,
 		comment is 'Internal predicates for analyzing source code.',
 		remarks is [
 			'Usage' - 'This is meant to be imported by any metric added to the system.',
@@ -214,10 +214,13 @@
 		extends_object(Entity, Ancestor).
 	ancestor(object, Entity, object, Ancestor) :-
 		instantiates_class(Entity, Ancestor),
-		% to account for meta-classes that can instantiate themselves
-		Entity \== Ancestor.
+		Entity \== Ancestor,
+		\+ instantiates_class(Ancestor, Entity),
+		\+ specializes_class(Ancestor, Entity).
 	ancestor(object, Entity, object, Ancestor) :-
-		specializes_class(Entity, Ancestor).
+		specializes_class(Entity, Ancestor),
+		\+ instantiates_class(Ancestor, Entity),
+		\+ specializes_class(Ancestor, Entity).
 
 
 

--- a/tools/code_metrics/test_entities.lgt
+++ b/tools/code_metrics/test_entities.lgt
@@ -155,3 +155,26 @@
 	instantiates(vehicle)).
 
 :- end_object.
+
+
+
+:- object(class,
+	instantiates(class),
+	specializes(abstract_class)).
+
+:- end_object.
+
+
+
+:- object(object,
+	instantiates(class)).
+
+:- end_object.
+
+
+
+:- object(abstract_class,
+	instantiates(class),
+	specializes(object)).
+
+:- end_object.

--- a/tools/code_metrics/tests.lgt
+++ b/tools/code_metrics/tests.lgt
@@ -23,9 +23,9 @@
 	extends(lgtunit)).
 
 	:- info([
-		version is 0.1,
+		version is 0.2,
 		author is 'Ebrahim Azarisooreh',
-		date is 2017/01/10,
+		date is 2017/02/27,
 		comment is 'Unit tests for code metrics framework.'
 	]).
 
@@ -46,6 +46,15 @@
 	]).
 
 	% DIT tests
+
+	test(dit_reflexive_obj) :-
+		depth_is(object, 2).
+
+	test(dit_reflexive_class) :-
+		depth_is(class, 1).
+
+	test(dit_reflexive_abstract_class) :-
+		depth_is(abstract_class, 3).
 
 	test(dit_obj_a) :-
 		depth_is(obj_a, 3).


### PR DESCRIPTION
Patching `ancestor/4` implementation in `code_metrics_utilities` category so that reflexive class definitions don't cause infinite loops.