### PR TITLE
Add -g/--goal options and Improve REPL for Tau Prolog

### DIFF
--- a/integration/logtalk_tau.js
+++ b/integration/logtalk_tau.js
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////
 //
 //  Integration file for Tau Prolog
-//  Last updated on May 26, 2020
+//  Last updated on Aug 26, 2020
 //
 //  This file is part of Logtalk <https://logtalk.org/>  
 //  Copyright 1998-2020 José Antonio Riaza Valverde and  
@@ -31,25 +31,77 @@ require("tau-prolog/modules/os.js")(pl);
 require("tau-prolog/modules/random.js")(pl);
 require("tau-prolog/modules/statistics.js")(pl);
 
-var max_answers = process.argv[2] || 100;
-var session = pl.create(50000);
-var compose = (f,g) => x => f(g(x));
-var show = x => console.log(pl.format_answer(x, session));
 const LOGTALKHOME = process.env.LOGTALKHOME;
-var repl = function() {
-    var query = readlineSync.question("?- ", {keepWhitespace: true}) + "\n";
-    session.query(query, {success: function(_goal) {
-        session.answers(function(answer) {
-            show(answer);
-            if(answer === false || pl.type.is_error(answer))
-                repl();
-        }, max_answers);
+
+var options = {};
+var args = process.argv.slice(2);
+for(var i = 0; i < args.length; i++) {
+    if((args[i] === "-g" || args[i] === "--goal") && args[i+1]) {
+        options.goal = args[i+1];
+        i++;
+    }
+}
+
+var session = pl.create(50000);
+const compose = (f,g) => x => f(g(x));
+const show = function(answer) {
+    console.log(pl.format_answer(answer, session, {quoted: true}));
+};
+const action = function(callback) {
+    var input = readlineSync.question("", {keepWhitespace: true}).trim();
+    switch(input) {
+        // next answer
+        case ";":
+            session.answer(next_answer(callback));
+            break;
+        // break
+        case "":
+            callback();
+            break;
+        // help
+        case "h":
+            console.log("Actions: ");
+            console.log(";\tredo");
+            console.log("RET\tbreak");
+            console.log("h\thelp");
+            action(callback);
+            break;
+        // unknown
+        default:
+            console.log("Unknown action: " + input + " (h for help)");
+            action(callback);
+            break;
+    }
+};
+const next_answer = function(callback) {
+    return function(answer) {
+        show(answer);
+        if(answer === false || pl.type.is_error(answer))
+            callback();
+        else
+            action(callback);
+    };
+};
+const query = function(goal, callback) {
+    if(goal.trim().length === 0) {
+        callback();
+        return;
+    }
+    session.query(goal, {success: function(_goal) {
+        session.answer(next_answer(callback));
     }, error: compose(repl, show)});
+};
+const repl = function() {
+    var goal = readlineSync.question("?- ", {keepWhitespace: true}) + "\n";
+    query(goal, repl);
 };
 session.consult(`${LOGTALKHOME}/adapters/tau.pl`, {success: function() {
     session.consult(`${LOGTALKHOME}/paths/paths.pl`, {success: function() {
         session.consult(`${LOGTALKHOME}/core/core.pl`, {success: function() {
-            repl();
+            if(options.goal)
+                query(options.goal, repl);
+            else
+                repl();
         }, error: show});
     }, error: show});
 }, error: show});

--- a/integration/taulgt.sh
+++ b/integration/taulgt.sh
@@ -3,7 +3,7 @@
 #############################################################################
 ## 
 ##   Integration script for  Tau Prolog
-##   Last updated on May 26, 2020
+##   Last updated on Aug 26, 2020
 ## 
 ##   This file is part of Logtalk <https://logtalk.org/>  
 ##   Copyright 1998-2020 Paulo Moura <pmoura@logtalk.org>
@@ -97,4 +97,4 @@ fi
 LOGTALK_STARTUP_DIRECTORY=$(pwd)
 export LOGTALK_STARTUP_DIRECTORY
 
-exec node --stack_size=10000 "$LOGTALKHOME/integration/logtalk_tau.js"
+exec node --stack_size=10000 "$LOGTALKHOME/integration/logtalk_tau.js" "$@"


### PR DESCRIPTION
Added **-g** and **--goal** options to run a goal from the command-line (#80). In addition, this new REPL asks the user what to do instead of looking for all the answers:

* **(;)** look for the next answer,
* **(h)** help,
* **(RET)** break execution.

