### PR TITLE
Relations to Category

### DIFF
--- a/examples/family/NOTES.md
+++ b/examples/family/NOTES.md
@@ -22,9 +22,9 @@ To load this example and for sample queries, please see the `SCRIPT.txt`
 file.
 
 This folder contains an implementation of the classical family tree Prolog
-example. This solution defines a root object, `relations`, with predicates
-for common family relations like `sister/2` and `father/2`. This root object
-can then be extended with objects defining the actual families using basic
+example. This solution defines a root category, `relations`, with predicates
+for common family relations like `sister/2` and `father/2`. This root category
+can then be imported into objects defining the actual families using basic
 `female/1`, `male/1`, and `parent/2` facts. The relation predicates always
-call the basic facts in _self_. Any number of family objects can be loaded
+calls the basic facts in _self_. Any number of family objects can be loaded
 at the same time.

--- a/examples/family/addams.lgt
+++ b/examples/family/addams.lgt
@@ -20,7 +20,7 @@
 
 
 :- object(addams,
-	extends(familytree)).
+	imports(relations)).
 
 	:- info([
 		version is 1:0:0,

--- a/examples/family/relations.lgt
+++ b/examples/family/relations.lgt
@@ -19,7 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-:- object(familytree).
+:- category(relations).
 
 	:- info([
 		version is 1:0:0,
@@ -58,4 +58,4 @@
 		::parent(Parent, Child),
 		Brother \== Child.
 
-:- end_object.
+:- end_category.

--- a/examples/family/simpsons.lgt
+++ b/examples/family/simpsons.lgt
@@ -20,7 +20,7 @@
 
 
 :- object(simpsons,
-	extends(familytree)).
+	imports(relations)).
 
 	:- info([
 		version is 1:0:0,

--- a/examples/family/simpsons_extended.lgt
+++ b/examples/family/simpsons_extended.lgt
@@ -34,8 +34,8 @@
 	male(abe).
 	male(herb).
 
-	female(Male) :-
-		^^female(Male).
+	female(Female) :-
+		^^female(Female).
 	female(gaby).
 	female(mona).
 


### PR DESCRIPTION
Change `family` example to use a category for the root/base rather than an object.

Signed-off-by: Paul Brown <pbrownpaul@gmail.com>