### PR TITLE
Write version to the DisplayVersion property in the registry during installation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -101,6 +101,12 @@ Contributions
 * FIXED: Cases in the `xml_parser` contribution where predicates were called
 as non-terminals.
 
+Installers and installation scripts
+-----------------------------------
+
+* FIXED: The Windows installer to write the Logtalk version to the registry
+`DisplayVersion` property. Fix contributed by the GitHub user SpecterShell.
+
 
 3.65.0 - April 27, 2023
 =======================

--- a/scripts/windows/logtalk.iss
+++ b/scripts/windows/logtalk.iss
@@ -32,6 +32,7 @@
 
 [Setup]
 AppName={#MyAppName}
+AppVersion={#MyAppVer}
 AppVerName={#MyAppName} {#MyAppVer}
 AppCopyright={#MyAppCopyright}
 AppPublisher={#MyAppPublisher}

--- a/scripts/windows/logtalk.iss
+++ b/scripts/windows/logtalk.iss
@@ -1,5 +1,5 @@
 ﻿; Logtalk Inno Setup script for generating Windows installers
-; Last updated on April 17, 2023
+; Last updated on May 12, 2023
 ; 
 ; This file is part of Logtalk <https://logtalk.org/>  
 ; Copyright 1998-2023 Paulo Moura <pmoura@logtalk.org>


### PR DESCRIPTION
This PR will make installer write the version to the DisplayVersion property in the registry (`HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Logtalk_is1`) for
- Displaying the installed version explicitly in Programs and Features
- Making it easy for some package managers (e.g. WinGet) to detect the installed version properly
![image](https://github.com/LogtalkDotOrg/logtalk3/assets/56779163/04591b54-8287-4c6e-8ac0-f7580c64b625)
