### PR TITLE
Problem: standalone applications using foreign libraries in SWI Prolog

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,6 +79,10 @@ Installers and installation scripts
 * CHANGED: The SWI-Prolog based Docker image to use `swipl:stable` instead
 of `swipl:latest`.
 
+* ADDED: SWI-Prolog embedding scripts support for specifying the foreign
+object action when building standalone saved states. Contributed by Yurii
+Rashkovskii.
+
 
 3.67.0 - July 4, 2023
 =====================

--- a/scripts/embedding/swipl/NOTES.md
+++ b/scripts/embedding/swipl/NOTES.md
@@ -38,5 +38,9 @@ Usage
 Use `swipl_logtalk_qlf.sh -h` or `swipl_logtalk_qlf.ps1 -h` for a list
 and description of the script options.
 
+The `-f Action` option allows passing the foreign object action when
+creating a standalone saved state. See the SWI-Prolog `qsave_program/2`
+predicate documentation on the `foreign(Action)` option for details.
+
 See the script usage examples in the `../SCRIPT.txt` file on how to
 create a SWI-Prolog saved state that includes a Logtalk application.

--- a/scripts/embedding/swipl/swipl_logtalk_qlf.ps1
+++ b/scripts/embedding/swipl/swipl_logtalk_qlf.ps1
@@ -5,7 +5,7 @@
 ##   compiler and runtime and optionally an application.qlf file with a
 ##   Logtalk application
 ## 
-##   Last updated on March 15, 2023
+##   Last updated on July 11, 2023
 ## 
 ##   This file is part of Logtalk <https://logtalk.org/>  
 ##   Copyright 2022 Hans N. Beck and Paulo Moura <pmoura@logtalk.org>
@@ -33,6 +33,7 @@ param(
 	[Parameter()]
 	[Switch]$c, 
 	[Switch]$x, 
+	[String]$f,
 	[String]$d = $pwd,
 	[String]$t,
 	[String]$n = "application",
@@ -49,7 +50,7 @@ param(
 function Write-Script-Version {
 	$myFullName = $MyInvocation.ScriptName
 	$myName = Split-Path -Path $myFullName -leaf -Resolve
-	Write-Output ($myName + " 0.15")
+	Write-Output ($myName + " 0.16")
 }
 
 function Get-Logtalkhome {
@@ -103,6 +104,7 @@ function Write-Usage-Help() {
 	Write-Output "Optional arguments:"
 	Write-Output "  -c compile library alias paths in paths and settings files"
 	Write-Output "  -x also generate a standalone saved state"
+	Write-Output "  -f foreign object action for standalone saved state (requires -x option; no default)"
 	Write-Output "  -d directory for generated QLF files (absolute path; default is current directory)"
 	Write-Output "  -t temporary directory for intermediate files (absolute path; default is an auto-created directory)"
 	Write-Output "  -n name of the generated saved state (default is application)"
@@ -126,6 +128,12 @@ function Check-Parameters() {
 	if ($v -eq $true) {
 		Write-Script-Version
 		Exit
+	}
+
+	if ($f -ne "") {
+		$foreign = ",foreign($f)"
+	} else {
+		$foreign = ""
 	}
 
 	if (-not(Test-Path $p)) { # cannot be ""
@@ -298,10 +306,10 @@ if ($l -ne "") {
 if ($x -eq $true) {
 	Set-Location $d
 	if ($l -ne "") {
-		$GoalParam = "[logtalk, application], qsave_program('" + $n + "', [goal($g), stand_alone(true)])"
+		$GoalParam = "[logtalk, application], qsave_program('" + $n + "', [goal($g),stand_alone(true)$foreign])"
 		swipl -g $GoalParam -t "halt"
 	} else {
-		$GoalParam = "[logtalk], qsave_program('" + $n + "', [goal($g), stand_alone(true)])"
+		$GoalParam = "[logtalk], qsave_program('" + $n + "', [goal($g),stand_alone(true)$foreign])"
 		swipl -g $GoalParam -t "halt"
 	}
 }

--- a/scripts/embedding/swipl/swipl_logtalk_qlf.sh
+++ b/scripts/embedding/swipl/swipl_logtalk_qlf.sh
@@ -6,7 +6,7 @@
 ##   compiler and runtime and optionally an application.qlf file with a
 ##   Logtalk application
 ## 
-##   Last updated on April 9, 2022
+##   Last updated on July 11, 2023
 ## 
 ##   This file is part of Logtalk <https://logtalk.org/>  
 ##   SPDX-FileCopyrightText: 1998-2023 Paulo Moura <pmoura@logtalk.org>
@@ -28,7 +28,7 @@
 
 
 print_version() {
-	echo "$(basename "$0") 0.15"
+	echo "$(basename "$0") 0.16"
 	exit 0
 }
 
@@ -108,6 +108,7 @@ paths="$LOGTALKHOME/paths/paths.pl"
 settings="$LOGTALKHOME/scripts/embedding/settings-embedding-sample.lgt"
 hooks="$LOGTALKHOME/adapters/swihooks.pl"
 compile="false"
+foreign=""
 
 usage_help()
 {
@@ -117,13 +118,14 @@ usage_help()
 	echo "code given its loader file. It can also generate a standalone saved state."
 	echo
 	echo "Usage:"
-	echo "  $(basename "$0") [-c] [-x] [-d directory] [-t tmpdir] [-n name] [-p paths] [-k hooks] [-s settings] [-l loader] [-g goal]"
+	echo "  $(basename "$0") [-c] [-x] [-f foreign] [-d directory] [-t tmpdir] [-n name] [-p paths] [-k hooks] [-s settings] [-l loader] [-g goal]"
 	echo "  $(basename "$0") -v"
 	echo "  $(basename "$0") -h"
 	echo
 	echo "Optional arguments:"
 	echo "  -c compile library alias paths in paths and settings files"
 	echo "  -x also generate a standalone saved state"
+	echo "  -f foreign object action for standalone saved state (requires -x option; no default)"
 	echo "  -d directory for generated QLF files (absolute path; default is current directory)"
 	echo "  -t temporary directory for intermediate files (absolute path; default is an auto-created directory)"
 	echo "  -n name of the generated saved state (default is application)"
@@ -137,11 +139,12 @@ usage_help()
 	echo
 }
 
-while getopts "cxd:t:n:p:k:s:l:g:vh" option
+while getopts "cxf:d:t:n:p:k:s:l:g:vh" option
 do
 	case $option in
 		c) compile="true";;
 		x) saved_state="true";;
+		f) f_arg="$OPTARG";;
 		d) d_arg="$OPTARG";;
 		t) t_arg="$OPTARG";;
 		n) n_arg="$OPTARG";;
@@ -155,6 +158,10 @@ do
 		*) usage_help; exit;;
 	esac
 done
+
+if [ "$f_arg" != "" ] ; then
+	foreign=",foreign($f_arg)"
+fi
 
 if [ "$d_arg" != "" ] ; then
 	directory="$d_arg"
@@ -299,9 +306,9 @@ fi
 if [ "$saved_state" == "true" ] ; then
 	cd "$directory" || exit 1
 	if [ "$loader" != "" ] ; then
-		swipl -g "[logtalk, application], qsave_program('$name', [goal($goal), stand_alone(true)])" -t "halt"
+		swipl -g "[logtalk, application], qsave_program('$name', [goal($goal),stand_alone(true)$foreign])" -t "halt"
 	else
-		swipl -g "[logtalk], qsave_program('$name', [goal($goal), stand_alone(true)])" -t "halt"
+		swipl -g "[logtalk], qsave_program('$name', [goal($goal),stand_alone(true)$foreign])" -t "halt"
 	fi
 fi
 


### PR DESCRIPTION
Current embedding script does nothing to ensure these are bundled together.

Solution: provide -f option to allow passing `foreign` setting (such as 'save')