### PR TITLE
Problem: difficult to get entity relations at loading time

### DIFF
--- a/core/core.pl
+++ b/core/core.pl
@@ -3285,6 +3285,30 @@ logtalk_load_context(entity_identifier, Entity) :-
 logtalk_load_context(entity_prefix, Prefix) :-
 	'$lgt_pp_entity_'(_, _, Prefix).
 
+logtalk_load_context(extends_protocol, Protocol) :-
+   '$lgt_pp_extended_protocol_'(Protocol, _, _, _, _).
+
+logtalk_load_context(implements_protocol, Protocol) :-
+   '$lgt_pp_implemented_protocol_'(Protocol, _, _, _, _).
+
+logtalk_load_context(extends_category, Category) :-
+   '$lgt_pp_extended_category_'(Category, _, _, _, _, _).
+
+logtalk_load_context(imports_category, Category) :-
+   '$lgt_pp_imported_category_'(Category, _, _, _, _, _).
+
+logtalk_load_context(extends_object, Object) :-
+   '$lgt_pp_extended_object_'(Object, _, _, _, _, _, _, _, _, _, _).
+
+logtalk_load_context(instantiates_class, Class) :-
+   '$lgt_pp_instantiated_class_'(Class, _, _, _, _, _, _, _, _, _, _).
+
+logtalk_load_context(specializes_class, Class) :-
+   '$lgt_pp_specialized_class_'(Class, _, _, _, _, _, _, _, _, _, _).
+
+logtalk_load_context(complements_object, Object) :-
+   '$lgt_pp_complemented_object_'(Object, _, _, _, _).
+
 logtalk_load_context(entity_type, Type) :-
 	(	'$lgt_pp_module_'(_) ->
 		Type = module
@@ -13899,7 +13923,10 @@ create_logtalk_flag(Flag, Value, Options) :-
 		source, file, basename, directory,
 		stream, target, flags,
 		term, term_position, variables, parameter_variables,
-		variable_names, variable_names(_), singletons, singletons(_)
+		variable_names, variable_names(_), singletons, singletons(_),
+		extends_protocol, implements_protocol, extends_category,
+		imports_category, imports_category, extends_object,
+		instantiates_class, specializes_class, complements_object
 	]),
 	'$lgt_source_file_context'(File, Lines),
 	(	'$lgt_pp_entity_'(Type, Entity, _) ->

--- a/tests/logtalk/predicates/logtalk_load_context_2/sample.lgt
+++ b/tests/logtalk/predicates/logtalk_load_context_2/sample.lgt
@@ -27,3 +27,9 @@
 	a(A,B,C,B,A).
 
 :- end_object.
+
+:- protocol(sample_protocol).
+:- end_protocol.
+
+:- protocol(sample_protocol_ext, extends(sample_protocol)).
+:- end_protocol.

--- a/tests/logtalk/predicates/logtalk_load_context_2/tests.lgt
+++ b/tests/logtalk/predicates/logtalk_load_context_2/tests.lgt
@@ -104,6 +104,38 @@
 		logtalk_load_context(stream, Stream),
 		assertz(result(stream, Stream)),
 		fail.
+    term_expansion((:- end_protocol), _) :-
+		logtalk_load_context(extends_protocol, V),
+		assertz(result(extends_protocol, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(implements_protocol, V),
+		assertz(result(implements_protocol, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(extends_category, V),
+		assertz(result(extends_object, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(imports_category, V),
+		assertz(result(imports_category, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(extends_object, V),
+		assertz(result(extends_object, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(instantiates_class, V),
+		assertz(result(instantiates_class, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(specializes_class, V),
+		assertz(result(specializes_class, V)),
+		fail.
+	term_expansion((:- end_object), _) :-
+		logtalk_load_context(complements_object, V),
+		assertz(result(complements_object, V)),
+		fail.
 
 	:- initialization((
 		logtalk_load_context(basename, Basename),
@@ -224,5 +256,11 @@
 	test(logtalk_load_context_2_22, true(File0 == File)) :-
 		object_property(hook, file(File0)),
 		logtalk_library_path(hook_file, File).
+
+    % test relations
+
+	test(logtalk_load_context_relations_extends_protocol) :-
+		result(extends_protocol, sample_protocol).
+	% TODO: finish relations coverage
 
 :- end_object.


### PR DESCRIPTION
This significantly inhibits the ability of term expansion to do its magic without also expanding on opening directives (which requires some extra effort).

Solution: provide relations through logtalk_load_context/2

---

I didn't complete the test suite or update the documentation, changelog, etc. because I want to run this proof-of-concept by you first.