### PR TITLE
Update logtalk_tester.1 to clarify initialization goal does not include a period

### DIFF
--- a/man/man1/logtalk_tester.1
+++ b/man/man1/logtalk_tester.1
@@ -78,7 +78,7 @@ Regular expression for excluding directories (using the \fIfind\fR command suppo
 Integration script command-line options (no default).
 .TP
 .BI \-g
-Initialization goal. Default is \fItrue\fR. Called after loading the Logtalk compiler and runtime.
+Initialization goal. Default is \fItrue\fR (no period). Called after loading the Logtalk compiler and runtime.
 .TP
 .BI \-r
 Random generator starting seed (no default).


### PR DESCRIPTION
When logtalk_tester is invoked with initialization goal `true.` (with period), the result is a broken test set.

This PR is simply a clarification that the default initialization goal is simply `true` (no period).