### PR TITLE
Renamed adapters/lvm.pl to xvm.pl. Fixed current_prolog_flag(version_…

### DIFF
--- a/adapters/xvm.pl
+++ b/adapters/xvm.pl
@@ -262,7 +262,7 @@
 
 '$lgt_prolog_feature'(prolog_dialect, xvm).
 '$lgt_prolog_feature'(prolog_version, v(Major, Minor, Patch)) :-
-	current_prolog_flag(version_data, xvm(Major, Minor, Patch, _)).
+	current_prolog_flag(version_data, xvmpl(Major, Minor, Patch, _)).
 '$lgt_prolog_feature'(prolog_compatible_version, '@>='(v(6, 3, 0))).
 
 '$lgt_prolog_feature'(encoding_directive, source).


### PR DESCRIPTION
Renamed adapters/lvm.pl to xvm.pl. Fixed current_prolog_flag(version_data, xvm(Major, Minor, Patch, _)) to be current_prolog_flag(version_data, xvmpl(Major, Minor, Patch, _)).